### PR TITLE
soft link dependency locations in conda build script

### DIFF
--- a/conda_package/pasta/build.sh
+++ b/conda_package/pasta/build.sh
@@ -1,2 +1,10 @@
 cd pasta
 $PYTHON setup.py install --single-version-externally-managed --record=record.txt  # Python command to install the script.
+
+mkdir $PYTHON/site-packages/bin
+ln -s $PREFIX/bin/mafft $PYTHON/site-packages/bin/mafft
+ln -s $PREFIX/bin/mafftdir $PYTHON/site-packages/bin/mafft/mafftdir
+ln -s $PREFIX/bin/hmmeralign $PYTHON/site-packages/bin/hmmeralign
+ln -s $PREFIX/bin/opal.jar $PYTHON/site-packages/bin/opal.jar
+ln -s $PREFIX/bin/fasttree $PYTHON/site-packages/bin/fasttree
+ln -s $PREFIX/bin/raxml $PYTHON/site-packages/bin/raxml


### PR DESCRIPTION
after installing bioconda package, PASTA repeatedly returns errors because it looks for `mafft`, `hmmeralign`, `opal.jar`, `fasttree`, and `raxml` not in the conda environment's binary directory, but in its Python version's site-packages directory. this is the workaround I've used which seems to work -- I don't think it's a great or stable solution, but it seems to work so far