### PR TITLE
dependencies: dendropy v4.5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ param = {
     'package_dir': {'pasta': 'pasta'},
     'test_suite': "pasta.test",
     'include_package_data': True,
-    'install_requires': ['dendropy>=4.00'],
+    'install_requires': ['dendropy==4.5.2'],
     'scripts' : [script_name,gui_script_name,'run_seqtools.py'],
     'zip_safe': True,
     'keywords': 'Phylogenetics Evolution Biology',


### PR DESCRIPTION
Dendropy with version higher than 4.5.2 breaks compatibility. One example is `_convert_node_to_root_polytomy` which was a function and became a method of the `Node` class.