### PR TITLE
drop the now unsupported U mode for open file

### DIFF
--- a/pasta/alignment.py
+++ b/pasta/alignment.py
@@ -867,7 +867,7 @@ class MultiLocusDataset(list):
             try:
                 if os.path.isdir(seq_fn):
                     raise Exception('"%s" is a directory. A path to file was expected.\nMake sure that you are using the multilocus mode when the input source is a directory.\nUse the path to a FASTA file if you are running in single-locus mode.' % seq_fn)
-                fileobj = open(seq_fn, 'rU')
+                fileobj = open(seq_fn, 'r')
                 sd.read(fileobj,
                         file_format=file_format,
                         datatype=datatype,

--- a/pasta/mainpasta.py
+++ b/pasta/mainpasta.py
@@ -193,7 +193,7 @@ def finish_pasta_execution(pasta_team,
     if tree_file:
         if not os.path.exists(tree_file):
             raise Exception('The tree file "%s" does not exist' % tree_file)
-        tree_f = open(tree_file, 'rU')
+        tree_f = open(tree_file, 'r')
         MESSENGER.send_info('Reading starting trees from "%s"...' % tree_file)
         try:
             tree_list = read_and_encode_splits(multilocus_dataset.dataset, tree_f,

--- a/pasta/test/support/sate_test_case.py
+++ b/pasta/test/support/sate_test_case.py
@@ -87,7 +87,7 @@ class SateTestCase(unittest.TestCase):
     def parse_fasta_file(self, file):
         if isinstance(file, str):
             _LOG.info('parsing fasta file {0!r}...'.format(file))
-            file_stream = open(file, 'rU')
+            file_stream = open(file, 'r')
         else:
             file_stream = file
         line_iter = iter(file_stream)
@@ -112,7 +112,7 @@ class SateTestCase(unittest.TestCase):
         file_stream = file_obj
         if isinstance(file_obj, str):
             _LOG.info('parsing score file {0!r}...'.format(file_obj))
-            file_stream = open(file_obj, 'rU')
+            file_stream = open(file_obj, 'r')
         return(float(file_stream.read().strip()))
 
     def parse_score_arg(self, arg):
@@ -129,7 +129,7 @@ class SateTestCase(unittest.TestCase):
         file_stream = file_obj
         if isinstance(file_obj, str):
             _LOG.info('parsing tree file {0!r}...'.format(file_obj))
-            file_stream = open(file_obj, 'rU')
+            file_stream = open(file_obj, 'r')
         t = dendropy.Tree()
         t.read_from_stream(file_stream, schema='newick')
         file_stream.close()
@@ -238,11 +238,11 @@ class SateTestCase(unittest.TestCase):
         all_equal = True
         f1 = files.pop(0)
         if isinstance(f1, str):
-            f1 = open(f1, 'rU')
+            f1 = open(f1, 'r')
         s1 = f1.read()
         for f2 in files:
             if isinstance(f2, str):
-                f2 = open(f2, 'rU')
+                f2 = open(f2, 'r')
             s2 = f2.read()
             if not s1 == s2:
                 all_equal = False

--- a/pasta/test/test_alignment.py
+++ b/pasta/test/test_alignment.py
@@ -54,9 +54,9 @@ class SeqDatasetTest(unittest.TestCase):
     #def testTaxonRelabeling(self):
     #    sd = SequenceDataset()
     #    fp = data_source_path('bad_names.fasta')
-    #    sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+    #    sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
     #    fp = data_source_path('bad_names.tree')
-    #    tree_list = read_and_encode_splits(sd.dataset, open(fp, 'rU'))
+    #    tree_list = read_and_encode_splits(sd.dataset, open(fp, 'r'))
     #    self.assertEqual(len(tree_list), 1)
     #    tree = tree_list[0]
 
@@ -85,7 +85,7 @@ class SeqDatasetTest(unittest.TestCase):
     def test100T(self):
         sd = SequenceDataset()
         fp = data_source_path('100T.fasta')
-        sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+        sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
         fp = data_source_path('100T.tree')
         tree_list = read_and_encode_splits(sd.dataset, open(fp, "rU"))
         self.assertEqual(len(tree_list), 1)
@@ -93,7 +93,7 @@ class SeqDatasetTest(unittest.TestCase):
     def test1000T(self):
         sd = SequenceDataset()
         fp = data_source_path('1000T.fasta')
-        sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+        sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
         fp = data_source_path('1000T.tree')
         tree_list = read_and_encode_splits(sd.dataset, open(fp, "rU"))
         self.assertEqual(len(tree_list), 1)
@@ -101,19 +101,19 @@ class SeqDatasetTest(unittest.TestCase):
     def testDNAFasta(self):
         sd = SequenceDataset()
         fp = data_source_path('anolis.fasta')
-        sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+        sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
 
     #def testDeleteMissing(self):
     #    sd = SequenceDataset()
     #    fp = data_source_path('missing.fasta')
-    #    sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+    #    sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
     #    self.assertFalse(sd.sequences_are_valid())
 
     #    self.assertTrue(sd.sequences_are_valid(True, None))
     #    aln = sd.relabel_for_sate()
 
     #    fp = data_source_path('delmissing.fasta')
-    #    sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+    #    sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
     #    del_aln = sd.relabel_for_sate()
     #    for k, v in aln.iteritems():
     #        self.assertEqual(v.upper(), del_aln[k].upper())
@@ -121,14 +121,14 @@ class SeqDatasetTest(unittest.TestCase):
     #def testMissingToAmbig(self):
     #    sd = SequenceDataset()
     #    fp = data_source_path('missing.fasta')
-    #    sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+    #    sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
     #    self.assertFalse(sd.sequences_are_valid())
 
     #    self.assertTrue(sd.sequences_are_valid(True, sd.alphabet.any_residue.symbol))
     #    aln = sd.relabel_for_sate()
 
     #    fp = data_source_path('ambigmissing.fasta')
-    #    sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+    #    sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
     #    ambig_aln = sd.relabel_for_sate()
     #    for k, v in aln.iteritems():
     #        self.assertEqual(v.upper(), ambig_aln[k].upper())

--- a/pasta/test/test_decomp.py
+++ b/pasta/test/test_decomp.py
@@ -21,7 +21,7 @@ class DecompTest(unittest.TestCase):
     def testLongestEdge(self):
         sd = SequenceDataset()
         fp = data_source_path('100T.fasta')
-        sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+        sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
         fp = data_source_path('100T.tree')
         tree_list = read_and_encode_splits(sd.dataset, open(fp, "rU"))
         self.assertEqual(len(tree_list), 1)
@@ -31,7 +31,7 @@ class DecompTest(unittest.TestCase):
     def testCentroidEdge(self):
         sd = SequenceDataset()
         fp = data_source_path('100T.fasta')
-        sd.read(open(fp, 'rU'), file_format='FASTA', datatype='DNA')
+        sd.read(open(fp, 'r'), file_format='FASTA', datatype='DNA')
         fp = data_source_path('100T.tree')
         tree_list = read_and_encode_splits(sd.dataset, open(fp, "rU"))
         self.assertEqual(len(tree_list), 1)

--- a/pasta/test/test_main.py
+++ b/pasta/test/test_main.py
@@ -79,7 +79,7 @@ class TestUnicodePathCharacters(SateTestCase):
         self.data_path = self.get_path(
                 name=unicode_name + '.fasta',
                 parent_dir=self.tmp_sub_dir)
-        src = open(data_file, 'rU')
+        src = open(data_file, 'r')
         out = open(self.data_path, 'w')
         for line in src:
             out.write(line)
@@ -107,7 +107,7 @@ class TestSpacesInPath(SateTestCase):
         self.data_path = self.get_path(
                 name=space_name + '.fasta',
                 parent_dir=self.tmp_sub_dir)
-        src = open(data_file, 'rU')
+        src = open(data_file, 'r')
         out = open(self.data_path, 'w')
         for line in src:
             out.write(line)

--- a/pasta/test/test_phylogenetic_tree.py
+++ b/pasta/test/test_phylogenetic_tree.py
@@ -57,7 +57,7 @@ class PhylogeneticTreeTest(unittest.TestCase):
 
     def phylogeneticTreeFromFile(self, treefile, file_format):
         dataset = Dataset()
-        dataset.read(open(treefile, 'rU'), schema=file_format)
+        dataset.read(open(treefile, 'r'), schema=file_format)
         dendropy_tree = dataset.tree_lists[0][0]
         tree = PhylogeneticTree(dendropy_tree)
         tree.calc_splits()

--- a/pasta/tools.py
+++ b/pasta/tools.py
@@ -96,13 +96,13 @@ def read_raxml_results(dir, dirs_to_delete, temp_fs, pasta_products=None, step_n
             id = f.split('.')[1]
             break
     raxml_log = os.path.join(dir, 'RAxML_log.%s' % id)
-    logsc = [x for x in open(raxml_log, 'rU').readlines() if x.find("Final GAMMA-based Score of best tree")!=-1]
+    logsc = [x for x in open(raxml_log, 'r').readlines() if x.find("Final GAMMA-based Score of best tree")!=-1]
     if logsc:
         score = float(logsc[0].split(" ")[-1])
     else:
-        score = float(open(raxml_log, 'rU').readlines()[-1].split()[1])
+        score = float(open(raxml_log, 'r').readlines()[-1].split()[1])
     raxml_result = os.path.join(dir, 'RAxML_result.%s' % id)
-    f = open(raxml_result, 'rU')
+    f = open(raxml_result, 'r')
     tree_str = f.read().strip()
     f.close()
     copy_temp_tree(raxml_result, pasta_products, step_num)
@@ -111,11 +111,11 @@ def read_raxml_results(dir, dirs_to_delete, temp_fs, pasta_products=None, step_n
     return score, tree_str
 
 def read_fasttree_results(dir, fasttree_restults_file, log, delete_dir=False, pasta_products=None, step_num=None):
-        f = open(fasttree_restults_file, 'rU')
+        f = open(fasttree_restults_file, 'r')
         tree_str = f.read().strip()
         f.close()
         score = None
-        for line in reversed(open(log, 'rU').readlines()):
+        for line in reversed(open(log, 'r').readlines()):
             if (line.split()[0] == 'Gamma20LogLk'):
                 score = float(line.split()[1])
                 break
@@ -956,8 +956,8 @@ class Randtree(TreeEstimator):
                                       temp_fs=self.temp_fs,
                                       pasta_products=pasta_products,
                                       step_num=step_num):
-            score = float(open(score_fn, 'rU').read().strip())
-            tree_str = open(fn, 'rU').read().strip()
+            score = float(open(score_fn, 'r').read().strip())
+            tree_str = open(fn, 'r').read().strip()
             copy_temp_tree(fn, pasta_products, step_num)
             for d in dirs_to_delete:
                 temp_fs.remove_dir(d)

--- a/pasta/tree.py
+++ b/pasta/tree.py
@@ -194,7 +194,7 @@ class PhylogeneticTree(object):
 
     def read_tree_from_file(self, treefile, file_format):
         dataset = Dataset()
-        dataset.read(open(treefile, 'rU'), schema=file_format)
+        dataset.read(open(treefile, 'r'), schema=file_format)
         dendropy_tree = dataset.trees_blocks[0][0]
         self._tree = dendropy_tree
         self.n_leaves = self.count_leaves()

--- a/run_pasta_gui.py
+++ b/run_pasta_gui.py
@@ -913,7 +913,7 @@ class PastaFrame(wx.Frame):
             if PASTA_GUI_ONLY_PRINTS_CONFIG:
                 self.log.AppendText("Command is:\n  '%s'\n" % "' '".join(command))
                 self.log.AppendText("config_file:\n#############################################################\n")
-                for line in open(self.process_cfg_file, 'rU'):
+                for line in open(self.process_cfg_file, 'r'):
                     self.log.AppendText(line)
                 self.log.AppendText("#############################################################\n")
                 self._remove_config_file()


### PR DESCRIPTION
Hi @smirarab, the bioconda build for SEPP currently fails because it depends on pasta which has the HMMER pin to 3.1.2. Furthermore, updating the pasta recipe also fails because your code base still uses the deprecated 'U' mode for file handling. This PR should fix the latter.
Once you merge, could you also create a new release for pasta and bump the version number. This is the cleanest way for a bioconda update.